### PR TITLE
Default args

### DIFF
--- a/SerialCommand.cpp
+++ b/SerialCommand.cpp
@@ -70,9 +70,9 @@ void SerialCommand::setDefaultHandler(void (*function)(const char *)) {
  * When the terminator character (default '\n') is seen, it starts parsing the
  * buffer for a prefix command, and calls handlers setup by addCommand() member
  */
-void SerialCommand::readSerial() {
-  while (Serial.available() > 0) {
-    char inChar = Serial.read();   // Read single available character, there may be more waiting
+void SerialCommand::readSerial(Stream &stream) {
+  while (stream.available() > 0) {
+    char inChar = stream.read();   // Read single available character, there may be more waiting
     #ifdef SERIALCOMMAND_DEBUG
       Serial.print(inChar);   // Echo back to serial stream
     #endif

--- a/SerialCommand.h
+++ b/SerialCommand.h
@@ -48,7 +48,7 @@ class SerialCommand {
     void addCommand(const char *command, void(*function)());  // Add a command to the processing dictionary.
     void setDefaultHandler(void (*function)(const char *));   // A handler to call when no valid command received.
 
-    void readSerial(Stream &stream);    // Main entry point.
+    void readSerial(Stream &stream = Serial);    // Main entry point.
     void clearBuffer();   // Clears the input buffer.
     char *next();         // Returns pointer to next token found in command buffer (for getting arguments to commands).
 

--- a/SerialCommand.h
+++ b/SerialCommand.h
@@ -48,7 +48,7 @@ class SerialCommand {
     void addCommand(const char *command, void(*function)());  // Add a command to the processing dictionary.
     void setDefaultHandler(void (*function)(const char *));   // A handler to call when no valid command received.
 
-    void readSerial();    // Main entry point.
+    void readSerial(Stream &stream);    // Main entry point.
     void clearBuffer();   // Clears the input buffer.
     char *next();         // Returns pointer to next token found in command buffer (for getting arguments to commands).
 


### PR DESCRIPTION
Added Serial as default argument for readSerial() to support users of the original library without code changes, while allowing future development using different stream.