### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -2,17 +2,17 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-SerialCommand KEYWORD1
+SerialCommand	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-addCommand        KEYWORD2
-setDefaultHandler KEYWORD2
-readSerial        KEYWORD2
-clearBuffer       KEYWORD2
-next              KEYWORD2
+addCommand	KEYWORD2
+setDefaultHandler	KEYWORD2
+readSerial	KEYWORD2
+clearBuffer	KEYWORD2
+next	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE currently requires the use of a single true tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords